### PR TITLE
feat: move schemas to accounts plugin

### DIFF
--- a/src/schemas/schema.graphql
+++ b/src/schemas/schema.graphql
@@ -28,15 +28,6 @@ type AddressValidationService {
   supportedCountryCodes: [String]
 }
 
-"A list of the possible types of `Address`"
-enum AddressType {
-  "Address can be used for payment transactions and invoicing"
-  billing
-
-  "Address can be used as a mailing address for sending physical items"
-  shipping
-}
-
 "The details of an `Address` to be created or updated"
 input AddressInput {
   "The street address / first line"
@@ -155,40 +146,6 @@ type Address {
 
   "Region. For example, a U.S. state"
   region: String!
-}
-
-"""
-Wraps a list of `Addresses`, providing pagination cursors and information.
-
-For information about what Relay-compatible connections are and how to use them, see the following articles:
-- [Relay Connection Documentation](https://facebook.github.io/relay/docs/en/graphql-server-specification.html#connections)
-- [Relay Connection Specification](https://facebook.github.io/relay/graphql/connections.htm)
-- [Using Relay-style Connections With Apollo Client](https://www.apollographql.com/docs/react/recipes/pagination.html)
-"""
-type AddressConnection {
-  "The list of nodes that match the query, wrapped in an edge to provide a cursor string for each"
-  edges: [AddressEdge]
-
-  """
-  You can request the `nodes` directly to avoid the extra wrapping that `NodeEdge` has,
-  if you know you will not need to paginate the results.
-  """
-  nodes: [Address]
-
-  "Information to help a client request the next or previous page"
-  pageInfo: PageInfo!
-
-  "The total number of nodes that match your query"
-  totalCount: Int!
-}
-
-"A connection edge in which each node is an `Address` object"
-type AddressEdge {
-  "The cursor that represents this node in the paginated results"
-  cursor: ConnectionCursor!
-
-  "The address"
-  node: Address
 }
 
 "Details about an error that was the result of validating an address that is invalid"


### PR DESCRIPTION
The `AddressType` and `AddressConnection` schemas were created in the `address-validation` plugin, but only used in the `accounts` plugin.

This PR moves these schemas to that plugin, where they are used.

https://github.com/reactioncommerce/api-plugin-accounts/pull/3