### PR TITLE
add spanish translations

### DIFF
--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -1,0 +1,20 @@
+[{
+  "i18n": "es",
+  "ns": "reaction-address",
+  "translation": {
+    "reaction-address": {
+      "addressValidation": {
+        "addNewItemButtonText": "Agregar servicio de validación de direcciones",
+        "cancelButtonText": "Cancelar",
+        "countryCodesLabel": "Filtro de país",
+        "countryCodesHelpText": "Utilice este servicio solo para direcciones en estos países",
+        "deleteItemButtonText": "Eliminar",
+        "entryFormSubmitButtonText": "Agregar servicio",
+        "helpText": "Agregue uno o más servicios para habilitar la validación de direcciones para esta tienda. Se utilizará el primer servicio que coincida con el filtro de país.",
+        "saveFailed": "Hubo un problema al guardar los cambios.",
+        "serviceNameLabel": "Servicio de validación",
+        "title": "Validación de dirección"
+      }
+    }
+  }
+}]

--- a/src/i18n/index.js
+++ b/src/i18n/index.js
@@ -1,4 +1,5 @@
 import en from "./en.json";
+import es from "./es.json";
 
 //
 // we want all the files in individual
@@ -6,5 +7,5 @@ import en from "./en.json";
 // automated translation software
 //
 export default {
-  translations: [...en]
+  translations: [...en, ...es]
 };


### PR DESCRIPTION
Signed-off-by: cristiancc <cristiancamilo.cucunuba@gmail.com>

Impact: **minor**
Type: **chore**

## Issue
The plugin is missing Spanish translations for the text on the admin 

## Solution
Add i18n file with translations
